### PR TITLE
fix: correct typo in GamingView.vue style

### DIFF
--- a/src/views/personal/GamingView.vue
+++ b/src/views/personal/GamingView.vue
@@ -50,7 +50,7 @@ import SectionHeader from '../../components/SectionHeader.vue';
 }
 
 .game-section {
-  background: @box-backround;
+  background: @box-background;
   padding: 1.5rem;
   border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
## Description

This PR fixes a typo in the CSS variable reference in GamingView.vue.

## Changes Made

- Changed `@box-backround` to `@box-background` on line 53

## Issue

The incorrect variable name `@box-backround` would cause the background style to not apply correctly. This fix ensures the proper CSS variable `@box-background` is referenced.

Fixes #28

---

💰 **Tips appreciated!** If this PR helps, consider sending USDT (TRC20) to:  
`TJL2uq9nC6aqqGTDSUaUg8KWepSh8htrft`